### PR TITLE
Various improvements

### DIFF
--- a/framework/sparql.rb
+++ b/framework/sparql.rb
@@ -123,6 +123,24 @@ def is_type s, rdf_type
   end
 end
 
+# TODO: Use escape helpers to escape URIs.
+def type_traces_to_uri rdf_type, path, uri
+  predicate_s = make_predicate_string path
+  sparql_query = "
+    SELECT ?s WHERE {
+     ?s a <#{rdf_type}> ;
+      #{predicate_s} <#{uri}> .
+    }
+  "
+  puts "running query #{sparql_query}"
+  query_result = direct_query sparql_query
+  if query_result
+    query_result.map {|result| result["s"]}
+  else
+    []
+  end
+end
+
 # Memoized function which verifies whether a user with particular
 # allowed_groups can see that a uri has a particular type.
 #


### PR DESCRIPTION
- Fix on encoding handling of elasticsearch response
- Fixes on parsing of config / environment variables
- Improvements on delta handling: Each change in a triple having a predicate that is also used in a mu-search property (-path), is now acted upon. Now however, more queries to the database are executed to check which subjects (first ones in the property chain) should be invalidated. With the current approach, this supplementary DB load seems inevitable. To me, the lowest hanging fruit to deal with this is (low to high):
  - Assume that uuid's are static once assigned and thus not act on delta triples containing the uuid-predicate. (otherwise property paths containing the uuid-predicate "trigger an update" for practically each delta) This would cut out the largest share of supplementary querying.
  - Include URI's of intermediary subjects into the elastic document. This way, invalidation becomes more straightforward: when a delta comes in for a property contained in the property paths config then invalidate all elastic documents containing this reference. Note that this "just shifts" some of the load from the database to elastic ... not sure about tradeoffs
  - Preprocess incoming delta's, building the longest possible "partial property chains" from them. This way, in some cases, not each predicate in the chain needs to be queried for.
  - With knowledge on the intermediary RDF-types in the property-path and (the rare type-information in delta's) some extra queries could be shaved off. 