### PR TITLE
Support for :has-no: and :has: search modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,15 +697,15 @@ The following sections list the flags that are currently implemented:
 
 ###### Term-level queries
 - `:term:` : [Term query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html)
-- `:terms:` : [Terms query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html), terms should be comma-separated, such as: `GET /documents/search?filter[:terms:tag]=fish,seafood`
+- `:terms:` : [Terms query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html), terms should be comma-separated, such as: `filter[:terms:tag]=fish,seafood`
 - `:prefix:` : [Prefix query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html)
 - `:wildcard:` : [Wildcard query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html)
 - `:regexp:` : [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html)
 - `:fuzzy:` : [Fuzzy query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html)
 - `:gt:`,`lt:`, `:gte:`, `:lte:` : [Range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html)
 - `:lt,gt:`, `:lte,gte:`, `:lt,gte:`, `:lte,gt:` : Combined [range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html), range limits should be comma-separated such as: `GET /documents/search?filter[:lte,gte:importance]=3,7`
-- `:has-no:`: Ensures the supplied property doesn't have a value. Since this is a boolean filter, the supplied filter value should always be `yes`. For example `filter[:has-no:translation]=yes`. Syntax may be subject to change.
-- `has`: The inverse of `:has-no:`. Forces the property to exist. Syntax may be subject to change.
+- `:has:`: Filter on documents having any value for the supplied field. To enable the filter, it's value must be `t`. E.g. `filter[:has:translation]=t`.
+- `:has-no:`: Filter on documents not having a value for the supplied field. To enable the filter, it's value must be `t`. E.g. `filter[:has-no:translation]=t`.
 
 ###### Full text queries
 - `:phrase:` : [Match phrase query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html)

--- a/README.md
+++ b/README.md
@@ -704,6 +704,8 @@ The following sections list the flags that are currently implemented:
 - `:fuzzy:` : [Fuzzy query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html)
 - `:gt:`,`lt:`, `:gte:`, `:lte:` : [Range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html)
 - `:lt,gt:`, `:lte,gte:`, `:lt,gte:`, `:lte,gt:` : Combined [range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html), range limits should be comma-separated such as: `GET /documents/search?filter[:lte,gte:importance]=3,7`
+- `:has-no:`: Ensures the supplied property doesn't have a value. Since this is a boolean filter, the supplied filter value should always be `yes`. For example `filter[:has-no:translation]=yes`. Syntax may be subject to change.
+- `has`: The inverse of `:has-no:`. Forces the property to exist. Syntax may be subject to change.
 
 ###### Full text queries
 - `:phrase:` : [Match phrase query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html)

--- a/framework/search.rb
+++ b/framework/search.rb
@@ -156,6 +156,32 @@ def construct_es_query_term type, filter_argument, val
       vals = val.split(',')
       { range: { field => { flags[0] => vals[0], flags[1] => vals[1] } } }
     end
+  when 'has'
+    ensuring_single_field_for 'has', fields do |field|
+      if val == 'yes'
+        { exists: { field: field }}
+      else
+        log.error("The 'has'-modifier only works for value 'yes'.")
+        { }
+      end
+    end
+  when 'has-no'
+    ensuring_single_field_for 'has-no', fields do |field|
+      if val == 'yes'
+        {
+          bool: {
+            must_not: {
+              exists: {
+                field: field
+              }
+            }
+          }
+        }
+      else
+        log.error("The 'has-no'-modifier only works for value 'yes'.")
+        { }
+      end
+    end
   when 'query'
     ensuring_single_field_for 'query', fields do |field|
       { query_string: { default_field: field, query: val } }

--- a/framework/search.rb
+++ b/framework/search.rb
@@ -158,16 +158,16 @@ def construct_es_query_term type, filter_argument, val
     end
   when 'has'
     ensuring_single_field_for 'has', fields do |field|
-      if val == 'yes'
+      if val == 't'
         { exists: { field: field }}
       else
-        log.error("The 'has'-modifier only works for value 'yes'.")
+        log.error("The 'has'-modifier only works for value 't'.")
         { }
       end
     end
   when 'has-no'
     ensuring_single_field_for 'has-no', fields do |field|
-      if val == 'yes'
+      if val == 't'
         {
           bool: {
             must_not: {
@@ -178,7 +178,7 @@ def construct_es_query_term type, filter_argument, val
           }
         }
       else
-        log.error("The 'has-no'-modifier only works for value 'yes'.")
+        log.error("The 'has-no'-modifier only works for value 't'.")
         { }
       end
     end


### PR DESCRIPTION
This PR implements `:has-no:`- and `:has:`-modifiers for filtering operations.  The behaviour of these tags is aimed to be identical to their equivalent in the [mu-cl-resources API](https://github.com/mu-semtech/mu-cl-resources#special-filters).
One can now specify something like `filter[:has-no:previousVersion]=yes` in a query for agenda-item, in order to return only those items that don't have a previous version (and thus are the latest version).