### PR TITLE
Fix remove_index double method definition

### DIFF
--- a/lib/mu_search/index_manager.rb
+++ b/lib/mu_search/index_manager.rb
@@ -168,7 +168,7 @@ module MuSearch
         indexes_to_remove.each do |index|
           @logger.debug("INDEX MGMT") { "Remove index #{index.name}" }
           index.mutex.synchronize do
-            remove_index index
+            remove_index index allowed_groups
             index.status = :deleted
           end
         end
@@ -356,23 +356,10 @@ module MuSearch
 
       # Remove index from IndexManager
       if @indexes.has_key? type_name
-        @indexes[type_name].delete_if { |_, value| value.name == index.name }
+        @indexes[type_name].delete_if { |_, value| value.name == index_name }
 
         # Remove index from triplestore and Elasticsearch
         remove_index_by_name index_name
-      end
-    end
-
-    # Removes the given index from the triplestore, Elasticsearch and
-    # the in-memory indexes cache of the IndexManager.
-    # Does not yield an error if index doesn't exist
-    def remove_index index
-      # Remove index from IndexManager
-      if @indexes.has_key? index.type_name
-        @indexes[index.type_name].delete_if { |_, value| value.name == index.name }
-
-        # Remove index from triplestore and Elasticsearch
-        remove_index_by_name index.name
       end
     end
 


### PR DESCRIPTION
This produces errors like the following:

```
search_1         | 2021-05-05T09:34:15.357483470Z INFO [#37] INDEX MGMT -- Removing eager index for type 'document' and allowed_groups [{"name"=>"documents", "variables"=>["human"]}] since indexes are configured not to be persisted.
search_1         | 2021-05-05T09:34:15.359107769Z ArgumentError: wrong number of arguments (given 2, expected 1)
search_1         | 2021-05-05T09:34:15.359125831Z          remove_index at /app/lib/mu_search/index_ma
```