### PR TITLE
by default index uri as a keyword field

### DIFF
--- a/lib/mu_search/index_manager.rb
+++ b/lib/mu_search/index_manager.rb
@@ -289,6 +289,7 @@ module MuSearch
           mappings["properties"] = {} if mappings["properties"].nil?
           # uuid must be configured as keyword to be able to collapse results
           mappings["properties"]["uuid"] = { type: "keyword" }
+          mappings["properties"]["uri"] = { type: "keyword" }
           # TODO deep merge custom and default settings
           settings = type_definition["settings"] || @configuration[:default_index_settings] || {}
           @elasticsearch.create_index index_name, mappings, settings


### PR DESCRIPTION
it makes little sense for the uri to be indexed as a free text field, this seems
to be a simple ommission when the uri field was added. I doubt it will break
existing searches but this should be properly tested. In most cases I expect it
to improve search performance if the uri field is used for matching