### PR TITLE
feat: Add multi_match support for fuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ The following sections list the flags that are currently implemented:
 - `:prefix:` : [Prefix query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html)
 - `:wildcard:` : [Wildcard query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html)
 - `:regexp:` : [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html)
-- `:fuzzy:` : [Fuzzy query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html)
+- `:fuzzy:` : [Fuzzy query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html) with [fuziness](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) set to `"AUTO"` and allowing to match multiple fields.
 - `:gt:`,`lt:`, `:gte:`, `:lte:` : [Range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html)
 - `:lt,gt:`, `:lte,gte:`, `:lt,gte:`, `:lte,gt:` : Combined [range query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html), range limits should be comma-separated such as: `GET /documents/search?filter[:lte,gte:importance]=3,7`
 - `:has:`: Filter on documents having any value for the supplied field. To enable the filter, it's value must be `t`. E.g. `filter[:has:translation]=t`.
@@ -840,12 +840,12 @@ The following sections list the flags that are currently implemented:
 - `:common:` [Common terms query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html). The flag takes additional options `cutoff_frequency` and `minimum_should_match` appended with commas such as `:common,{cutoff_frequence},{minimum_should_match}:{field}`. The `cutoff_frequency` can also be set application-wide in [the configuration file](#configuration-options).
 
 ###### Custom queries
-- `:fuzzy_match:` : [Fuzzy query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html) with [fuziness](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) set to `"AUTO"`.
 - `:fuzzy_phrase:` : A fuzzy phrase query based on [span_near](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html) and [span_multi](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html). See also [this](https://stackoverflow.com/questions/38816955/elasticsearch-fuzzy-phrases) Stack Overflow issue or [the code](./framework/elastic_query_builder.rb).
 
 Currently searching on multiple fields is only supported for the following flag:
 - `:phrase:`
 - `:phrase_prefix:`
+- `:fuzzy:`
 
 Multiple filter parameters are supported.
 

--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -143,7 +143,14 @@ class ElasticQueryBuilder
       {
         multi_match: { query: value, type: flag, fields: multi_match_fields }.compact
       }
-    when "term", "fuzzy", "prefix", "wildcard", "regexp"
+    when "fuzzy"
+      # Using `nil` instead of `*.*` to match all fields when no fields are specified, because `nil` will only match
+      # all possible fields while `*.*` will match all (also conflicting, i.e. non keyword or text fields) fields.
+      multi_match_fields = fields == ["_all"] ? nil : fields
+      {
+        multi_match: { query: value, fields: multi_match_fields, fuzziness: "AUTO" }.compact
+      }
+    when "term", "prefix", "wildcard", "regexp"
       ensure_single_field_for flag, fields do |field|
         {
           flag => { field => value }
@@ -153,14 +160,6 @@ class ElasticQueryBuilder
       ensure_single_field_for flag, fields do |field|
         {
           terms: { field => value.split(",") }
-        }
-      end
-    when "fuzzy_match"
-      ensure_single_field_for flag, fields do |field|
-        {
-          fuzzy: {
-            field => { value: value, fuzziness: "AUTO" }
-          }
         }
       end
     when "fuzzy_phrase"


### PR DESCRIPTION
This PR adds support to match multiple fields (or all with `_all`) for the fuzzy flag