### PR TITLE
Allow to specify wildcards and per-field boosts in fields parameter

### DIFF
--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -275,7 +275,7 @@ class ElasticQueryBuilder
     modifier = nil
     fields_s = filter_key
 
-    match = /(?:\:)([^ ]+)(?::)([\w,.]*)/.match filter_key
+    match = /(?:\:)([^ ]+)(?::)([\w,.^*]*)/.match filter_key
     if match
       modifier = match[1]
       fields_s = match[2]


### PR DESCRIPTION
For search operations that allow wildcards in field names and per-field boosts, the special characters `^` and `*` must be allowed in the fields param.

See also https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-simple-query-string-query.html#simple-query-string-boost

E.g. query param `filter[:sqs:title^3,*_name,description]=test` will translate to `"fields": [ "title^3", "*_name", "description" ]` in the ES query