### PR TITLE
initial support for indexing language strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+## v0.8.0
 ## v0.8.0-beta.4
 **Features**
 - Allow to specify wildcards and per-field boosts in fields parameter

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Next, add the mu-search and accompanying elasticsearch service to `docker-compos
 ```yml
 services:
   search:
-    image: semtech/mu-search:0.8.0-beta.4
+    image: semtech/mu-search:0.8.0
     links:
       - db:database
     volumes:
@@ -230,7 +230,7 @@ Next, add the following mounted volumes to the mu-search service in `docker-comp
 ```yml
 services:
   search:
-    image: semtech/mu-search:0.8.0-beta.4
+    image: semtech/mu-search:0.8.0
     volumes:
       - ./config/search:/config
       - ./data/files:/data

--- a/lib/mu_search/property_definition.rb
+++ b/lib/mu_search/property_definition.rb
@@ -1,0 +1,51 @@
+module MuSearch
+  class PropertyDefinition
+    PROPERTY_TYPES = ["simple", "nested", "attachment", "language-string"]
+    attr_reader :name, :type, :rdf_type, :path, :pipeline, :sub_properties
+
+    def initialize(name: , path:,  type: "auto", rdf_type: nil, sub_properties:)
+      raise "invalid type" unless PROPERTY_TYPES.include?(type)
+      raise "path needs to be an array" unless path.is_a?(Array)
+      @name = name
+      @path = path.is_a?(String) ? [path] : path
+      @type = type
+
+      if type == "nested"
+        @rdf_type = rdf_type
+        @sub_properties = sub_properties
+      end
+    end
+
+    def self.from_json_config(name, config)
+      type = "simple"
+      rdf_type = sub_properties = pipeline = nil
+      if config.is_a?(Hash)
+        path = config["via"].is_a?(Array) ? config["via"] : [config["via"]]
+        if config.key?("attachment_pipeline")
+          type = "attachment"
+        elsif config.key?("properties")
+          type = "nested"
+          sub_properties = config["properties"].map do |subname, subconfig|
+            from_json_config(subname, subconfig)
+          end
+          rdf_type = config["rdf_type"]
+        elsif config.key?("type") && config["type"] == "language-string"
+          type = "language-string"
+        end
+      elsif config.is_a?(Array)
+        path = config
+      else
+        path = [config]
+      end
+
+      PropertyDefinition.new(
+        name: name,
+        type: type,
+        path: path,
+        rdf_type: rdf_type,
+        sub_properties: sub_properties,
+      )
+    end
+
+  end
+end

--- a/rfcs/multi-language-search.md
+++ b/rfcs/multi-language-search.md
@@ -2,7 +2,7 @@
 Stage: Draft
 Start Date: 17-10-2022
 Release Date: Unreleased
-RFC PR: 
+RFC PR: https://github.com/mu-semtech/mu-search/pull/57
 ---
 
 # multilang support in musearch
@@ -50,7 +50,7 @@ When storing multiple languages in one index there are three common ways of stor
 ```
 
 
-Of these, only language containers and postfixed fields allow a user to define custom tokenizers and analysers for specific languages. So the expanded form should not be considered a candidate. 
+Of these, only language containers and postfixed fields allow a user to define custom tokenizers and analysers for specific languages. So the expanded form should not be considered a candidate for storage. 
 
 Of the two remaining options the language container seems the most robust solution, by nesting the languages we make parsing and finding the relative languages a lot easier and avoid the chance (however small) of conflicting with another defined property.
 
@@ -61,7 +61,7 @@ This needs to be researched, currently no idea how this is typically handled. A 
 ```json
 {
 "label": {
-    "none": "The Queen",
+    "default": "The Queen",
   }
 }
 ```
@@ -114,7 +114,7 @@ A typical type/index definition looks like this currently
 In essence musearch is not aware of the type of data being indexed, rather this is offloaded to elasticsearch. For language tagged literals it should be possible to specify the fact that the language tag needs to be stored. 
 
 mu-search already supports objects instead of a plain path for properties for both nested objects and attachment pipelines (as shown above).
-This RFC suggests expanding the object with an optional `literal_type` to specify a specific type. Currently only two types would be offered: `string` and `language-string`. `string` would be the default if literal_type is not defined. An example:
+This RFC suggests expanding the object with an optional `type` to specify a specific type. Currently only three types would be offered: `simple`, `nested` and `language-string`. `simple` would be the default if type is not defined, nested applies to any property that is a hash and has a `properties` key. An example:
 
 ```json
   {
@@ -124,7 +124,7 @@ This RFC suggests expanding the object with an optional `literal_type` to specif
       "properties": {
         "title": {
           "via": "http://purl.org/dc/terms/title",
-          "literal_type": "language-string"
+          "type": "language-string"
         },
         "author": "http://purl.org/dc/terms/author",
         "related": {
@@ -132,7 +132,7 @@ This RFC suggests expanding the object with an optional `literal_type` to specif
             "^http://purl.org/dc/terms/related",
             "http://purl.org/dc/terms/title"
           ],
-          "literal_type": "language-string"
+          "type": "language-string"
         },
         "theme": [
           "http://purl.org/dc/terms/theme",


### PR DESCRIPTION
implements #57 , though  type should be specified as "type" instead of literal_type.

Example config:
```json
    {
      "type": "case",
      "on_path": "cases",
      "rdf_type": "http://mu.semte.ch/vocabularies/ext/Case",
      "properties": {
          "title": {
              "via": "http://purl.org/dc/terms/title",
              "type": "language-string"
          }
      }
    },
```

would allow searching on  the field `title.en` and `title.nl` if you have dutch and english titles. literals without a language are mapped onto a `default` field, so `title.default`