### PR TITLE
fix: match delta predicates in both directions

### DIFF
--- a/lib/mu_search/index_definition.rb
+++ b/lib/mu_search/index_definition.rb
@@ -129,8 +129,8 @@ module MuSearch
     end
 
     def full_property_paths_for(property)
-      if @property_path_cache.has_key?(property)
-        return @property_path_cache[property] + @property_path_cache["^#{property}"]
+      if matches_property?(property)
+        @property_path_cache[property] + @property_path_cache["^#{property}"]
       end
     end
 


### PR DESCRIPTION
This should ensure that deltas are handled correctly even when a predicate only appears in the config in the backwards direction `^property`.