### PR TITLE
put delta handling and lookups in a separate thread

### DIFF
--- a/lib/mu_search/index_manager.rb
+++ b/lib/mu_search/index_manager.rb
@@ -51,14 +51,14 @@ module MuSearch
 
         indexes_to_update.each do |index|
           index.status = :invalid if force_update
-          update_index index
-        end
-
-        if indexes_to_update.any? { |index| index.status == :invalid }
-          @logger.warn("INDEX MGMT") { "Not all indexes are up-to-date. Search results may be incomplete." }
         end
       end
-
+      indexes_to_update.each do |index|
+        update_index index
+      end
+      if indexes_to_update.any? { |index| index.status == :invalid }
+          @logger.warn("INDEX MGMT") { "Not all indexes are up-to-date. Search results may be incomplete." }
+      end
       indexes_to_update
     end
 

--- a/lib/mu_search/update_handler.rb
+++ b/lib/mu_search/update_handler.rb
@@ -113,7 +113,7 @@ module MuSearch
               @logger.error("UPDATE HANDLER") { "Update of subject <#{subject}> failed" }
               @logger.error("UPDATE HANDLER") { e.full_message }
             end
-            sleep 5
+            sleep 0.5
           end
         end
       end


### PR DESCRIPTION
by moving this outside of the http request handling we can handle more requests (should not block regular search requests or other updates). also moves handling of delta's to a queue, which enforces correct ordering and lessens load on the database. 

not merged into the update_handler, since they are separate concerns. the update handler itself may at some time be used by the initial indexing operation for example