### PR TITLE
Use tagged base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## latest
+- fix: Use tagged base image of mu-jruby-template
 
 ## v0.10.0-beta.1
 - change: put delta handling and lookups in a separate thread

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-jruby-template
+FROM semtech/mu-jruby-template:2.13.0
 
 LABEL maintainer="redpencil <info@redpencil.io>"
 # 200MB


### PR DESCRIPTION
A new version of semtech/mu-jruby-template has been released. Use this as base image instead of depending on `latest`.