### PR TITLE
Support kebab-cased property names

### DIFF
--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -290,7 +290,7 @@ class ElasticQueryBuilder
     modifier = nil
     fields_s = filter_key
 
-    match = /(?:\:)([^ ]+)(?::)([\w,.^*]*)/.match filter_key
+    match = /(?:\:)([^ ]+)(?::)([\w-,.^*]*)/.match filter_key
     if match
       modifier = match[1]
       fields_s = match[2]


### PR DESCRIPTION
`-` isn't covered by `\w` in a regex, hence only part of a kebab-cased property name matches the regex to split the filter flag from the fields.

E.g. previously `':gte:order-date'` resulted in `['gte', ['order']]` while the expected result is `['gte', ['order-date']]`