### PR TITLE
Add support for nested objects in delta handling

### DIFF
--- a/lib/mu_search/delta_handler.rb
+++ b/lib/mu_search/delta_handler.rb
@@ -152,7 +152,14 @@ module MuSearch
               # we are not at the end of the path and the object is a literal
               @logger.debug("DELTA") { "Discarding path because object is not a URI, but #{object_type}" }
             else
-              subjects.concat(query_for_subjects_to_triple(triple, config.related_rdf_types, path, i, is_inverse?(property), is_addition))
+              subjects_for_property = query_for_subjects_to_triple(
+                triple,
+                config.related_rdf_types,
+                path,
+                i,
+                is_inverse?(property),
+                is_addition)
+              subjects.concat(subjects_for_property)
             end
           end
         end
@@ -184,6 +191,10 @@ module MuSearch
     def query_for_subjects_to_triple(triple, rdf_types, path, i, is_inverse, is_addition)
       property_path_to_target = path.take(i) # path from start to the triple, excluding the triple itself
       property_path_from_target = path.drop(i + 1) # path from the triple until the end
+      # escaping values for usage in the SPARQL query
+      path_to_target_term = MuSearch::SPARQL::make_predicate_string(property_path_to_target)
+      path_from_target_term = MuSearch::SPARQL::make_predicate_string(property_path_from_target)
+
       subject_value = triple["subject"]["value"]
       predicate_value = triple["predicate"]["value"]
       triple_object = triple["object"]
@@ -191,9 +202,7 @@ module MuSearch
       object_type = triple_object["type"]
       object_datatype = triple_object["datatype"]
       object_language = triple_object["xml:lang"]
-      # escaping values for usage in the SPARQL query
-      path_to_target_term = MuSearch::SPARQL::make_predicate_string(property_path_to_target)
-      path_from_target_term = MuSearch::SPARQL::make_predicate_string(property_path_from_target)
+
       if object_type == "uri"
         object_term = sparql_escape_uri(object_value)
       elsif object_language
@@ -204,24 +213,33 @@ module MuSearch
         object_term = %(#{object_value.sparql_escape})
       end
 
-      # based on the direction of the predicate, determine the target to which the property_path leads
+      rdf_type_terms = rdf_types.map{ |rdf_type| sparql_escape_uri(rdf_type)}
+
+      # Based on the direction of the predicate, determine the target to which the property_path leads
       target_subject_term = is_inverse ? sparql_escape_uri(object_value) : sparql_escape_uri(subject_value)
       target_object_term = is_inverse ? sparql_escape_uri(subject_value) : object_term
 
+      # Build SPARQL query that tries to match the full path in the triplestore
       sparql_query = "SELECT DISTINCT ?s WHERE {\n"
       sparql_query += "\t ?s a ?type. \n"
-      sparql_query += "FILTER(?type IN (#{rdf_types.map{ |rdf_type| sparql_escape_uri(rdf_type)}.join(',')})) . \n"
-      # Check path from start to the triple
+      sparql_query += "FILTER(?type IN (#{rdf_type_terms.join(',')})) . \n"
       if property_path_to_target.length == 0
-        # triple is at the root. We only need to check if it has the correct rdf_type
+        # Triple is at the root. We only need to check if it has the correct rdf_type
         sparql_query += "\t VALUES ?s { #{target_subject_term} } . \n"
       else
+        # Check path from root to the triple
         sparql_query += "\t ?s #{path_to_target_term} #{target_subject_term} . \n"
       end
-      sparql_query += "\t #{sparql_escape_uri(subject_value)} #{sparql_escape_uri(predicate_value)} #{object_term} . \n" if is_addition
-      # Check path from the triple to the end
-      if is_addition && property_path_from_target.length > 0
-        sparql_query += "\t #{target_object_term} #{path_from_target_term} ?foo. \n"
+      if is_addition
+        # Check the delta triple itself
+        sparql_query += "\t #{sparql_escape_uri(subject_value)} #{sparql_escape_uri(predicate_value)} #{object_term} . \n"
+        # Check path from the triple to the end
+        if property_path_from_target.length > 0
+          sparql_query += "\t #{target_object_term} #{path_from_target_term} ?foo. \n"
+        end
+      # else:
+      #   in case of a deletion, we cannot check the remainder of the path
+      #   as the triple no longer exists in the triplestore
       end
       sparql_query += "}"
 

--- a/lib/mu_search/index_definition.rb
+++ b/lib/mu_search/index_definition.rb
@@ -169,18 +169,23 @@ module MuSearch
       end
     end
 
-    def build_property_paths_for_properties(properties)
+    def build_property_paths_for_properties(properties, root_path = [])
       properties.map do |prop_name, definition|
+        # Ensure path is an array of predicates
         if definition.is_a?(Hash) and !definition["via"].nil?
-          definition = definition["via"]
-        end
-        if definition.is_a?(Array)
-          path = definition
+          path = (root_path + [definition["via"]]).flatten
+
+          # Recursively walk down the nested object definition
+          unless definition["properties"].nil?
+            build_property_paths_for_properties(definition["properties"], path)
+          end
         else
-          path = [definition]
+          path = (root_path + [definition]).flatten
         end
-        path.each do |property|
-          @property_path_cache[property] << path
+
+        # Add cache entry for each predicate the path consists of
+        path.each do |predicate|
+          @property_path_cache[predicate] << path
         end
       end
     end

--- a/lib/mu_search/index_definition.rb
+++ b/lib/mu_search/index_definition.rb
@@ -169,18 +169,18 @@ module MuSearch
       end
     end
 
-    def build_property_paths_for_properties(properties, root_path = [])
-      properties.map do |prop_name, definition|
-        # Ensure path is an array of predicates
-        if definition.is_a?(Hash) and !definition["via"].nil?
-          path = (root_path + [definition["via"]]).flatten
+    def build_property_paths_for_properties(properties)
+      property_definitions = properties.map { |key, cfg| PropertyDefinition.from_json_config(key, cfg) }
+      build_property_paths_for_property_definitions(property_definitions)
+    end
 
-          # Recursively walk down the nested object definition
-          unless definition["properties"].nil?
-            build_property_paths_for_properties(definition["properties"], path)
-          end
-        else
-          path = (root_path + [definition]).flatten
+    def build_property_paths_for_property_definitions(property_definitions, root_path = [])
+      property_definitions.map do |definition|
+        path = root_path + definition.path
+
+        # Recursively walk down the nested object definition
+        if definition.type == "nested"
+          build_property_paths_for_property_definitions(definition.sub_properties, path)
         end
 
         # Add cache entry for each predicate the path consists of


### PR DESCRIPTION
Currently an item isn't reindexed if a property of a nested object changes because the properties of the nested objects are missing in the property path cache. This PR recursively walks down the nested object definitions while building the property path cache in the index definition. As such, incoming delta triples will match the property path cache and enforce a reindex of the document. 

Most important changes reside in `index_definition.rb`. Changes in `delta_handler.rb` are just code restructuring. None of the logic changed there.

~Builds upon #81 because of the nicer developer experience and usage of the utils from `Mu`-module.~