### PR TITLE
Fetch language from CONSTRUCT query results during document index

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,12 @@ For example:
                   "via": "http://purl.org/dc/elements/1.1/title",
                   "type": "language-string"
                 }
+            },
+            "mappings": {
+              "properties": {
+                "title.default" : { "type" : "text" },
+                "title.en": { "type" : "text" }
+              }
             }
          }
       ]
@@ -544,10 +550,10 @@ For example:
 
 When setting a property type to language-string, mu-search will include the language tag of the literal in the search index. In the above example the title field would be expanded to a language container in the document:
 ```json
-{ 
-  "title": { 
-    "en": "the english title",
-    "default": "this literal had no language tag"
+{
+  "title": {
+    "en": ["the english title"],
+    "default": ["this literal had no language tag"]
   }
 }
 ```

--- a/lib/sparql-client.rb
+++ b/lib/sparql-client.rb
@@ -1,0 +1,32 @@
+# Monkeypatching SPARQL::Client to correctly parse language tag for CONSTRUCT queries
+module SPARQL
+  class Client
+    ##
+    # @param  [Hash{String => String}] value
+    # @return [RDF::Value]
+    # @see    https://www.w3.org/TR/sparql11-results-json/#select-encode-terms
+    # @see    https://www.w3.org/TR/rdf-sparql-json-res/#variable-binding-results
+    def self.parse_json_value(value, nodes = {})
+      case value['type'].to_sym
+        when :bnode
+          nodes[id = value['value']] ||= RDF::Node.new(id)
+        when :uri
+          RDF::URI.new(value['value'])
+        when :literal
+          # Monkey patch: add support for 'lang' instead of only 'xml:lang'
+          # SELECT queries return the language in 'xml:lang',
+          # but CONSTRUCT queries return them in 'lang'
+          language = value['xml:lang'] || value['lang']
+          RDF::Literal.new(value['value'], datatype: value['datatype'], language: language)
+        when :'typed-literal'
+          RDF::Literal.new(value['value'], datatype: value['datatype'])
+        when :triple
+          s = parse_json_value(value['value']['subject'], nodes)
+          p = parse_json_value(value['value']['predicate'], nodes)
+          o = parse_json_value(value['value']['object'], nodes)
+          RDF::Statement(s, p, o)
+        else nil
+      end
+    end
+  end
+end

--- a/web.rb
+++ b/web.rb
@@ -9,6 +9,7 @@ require 'open3'
 require 'webrick'
 
 require_relative 'lib/logger.rb'
+require_relative 'lib/sparql-client.rb'
 require_relative 'lib/mu_search/sparql.rb'
 require_relative 'lib/mu_search/authorization_utils.rb'
 require_relative 'lib/mu_search/delta_handler.rb'


### PR DESCRIPTION
Instead of executing a separate query for each language-string property fetch the language tag from the CONSTRUCT query results.

Requires a monkeypatch of the SPARQL::Client since the language isn't correctly parsed from the JSON response of a CONSTRUCT query. In SELECT queries the language is returned in `xml:lang` but in CONSTRUCT queries it's returned in `lang`.

Also updates the README because the format of the indexed value wasn't correctly documented.