### PR TITLE
Add flag to enable exact counts of search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**Features**
+- Add query param to get exact count in search results
+
 ## v0.10.0-beta.3
 - change: Use 1 construct query instead of 1 query per property to fetch properties for a document
 

--- a/README.md
+++ b/README.md
@@ -919,6 +919,8 @@ GET /documents/search?filter[name]=fish&page[number]=2&page[size]=20
 
 The page number is zero-based.
 
+By default the search endpoint doesn't return exact result counts if the result set contains more than 10K items. To enable exact counts pass `count=exact` as query param (at the cost of some performance).
+
 ##### Highlighting
 
 Highlighting is specified using the `highlight[:fields:]` query parameter, where a comma separated list of fields you want highlighted should be provided.
@@ -996,7 +998,6 @@ This section gives an overview of all configurable options in the search configu
 - (*) **max_batches** : maximum number of batches to index. May result in an incomplete index and should therefore only be used during development. Defaults to 1.
 - (*) **number_of_threads** : number of threads to use during indexing. Defaults to 1.
 - (*) **update_wait_interval_minutes** : number of minutes to wait before applying an update. Allows to prevent duplicate updates of the same documents. Defaults to 1.
-- (*) **use_exact_counts** : flag to ensure exact result counts are returned in search requests (at the cost of some performance). Defaults to `false`.
 - (*) **common_terms_cutoff_frequency** : default cutoff frequency for a [Common terms query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html). Defaults to 0.0001. See [supported search methods](#supported-search-methods).
 - (*) **enable_raw_dsl_endpoint** : flag to enable the [raw Elasticsearch DSL endpoint](#api). This endpoint is disabled by default for security reasons.
 - (*) **attachments_path_base** : path inside the Docker container where files for the attachment pipeline are mounted. Defaults to `/data`.

--- a/README.md
+++ b/README.md
@@ -996,6 +996,7 @@ This section gives an overview of all configurable options in the search configu
 - (*) **max_batches** : maximum number of batches to index. May result in an incomplete index and should therefore only be used during development. Defaults to 1.
 - (*) **number_of_threads** : number of threads to use during indexing. Defaults to 1.
 - (*) **update_wait_interval_minutes** : number of minutes to wait before applying an update. Allows to prevent duplicate updates of the same documents. Defaults to 1.
+- (*) **use_exact_counts** : flag to ensure exact result counts are returned in search requests (at the cost of some performance). Defaults to `false`.
 - (*) **common_terms_cutoff_frequency** : default cutoff frequency for a [Common terms query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html). Defaults to 0.0001. See [supported search methods](#supported-search-methods).
 - (*) **enable_raw_dsl_endpoint** : flag to enable the [raw Elasticsearch DSL endpoint](#api). This endpoint is disabled by default for security reasons.
 - (*) **attachments_path_base** : path inside the Docker container where files for the attachment pipeline are mounted. Defaults to `/data`.

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,6 @@
     "batch_size": 12,
     "max_batches": 1,
     "automatic_index_updates" : true,
-    "use_exact_counts": false,
     "eager_indexing_groups" : [[{"name" : "documents", "variables" : ["human"]}],
                                [{"name" : "documents", "variables" : ["chicken"]}]],
     "attachments_path_base" : "/local/files/directory",

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,8 @@
 {
     "batch_size": 12,
     "max_batches": 1,
-    "automatic_index_updates" : true ,
+    "automatic_index_updates" : true,
+    "use_exact_counts": false,
     "eager_indexing_groups" : [[{"name" : "documents", "variables" : ["human"]}],
                                [{"name" : "documents", "variables" : ["chicken"]}]],
     "attachments_path_base" : "/local/files/directory",

--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -86,6 +86,7 @@ class ElasticQueryBuilder
   end
 
   def build_pagination
+    @es_query["track_total_hits"] = true if @configuration[:use_exact_counts]
     @es_query["from"] = @page_number * @page_size
     @es_query["size"] = @page_size
     self

--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -3,15 +3,16 @@
 # This is your one-stop shop for the construction of search queries
 # and the mapping of search query params to Elasticsearch Query DSL
 class ElasticQueryBuilder
-  attr_reader :page_number, :page_size, :sort, :collapse_uuids
+  attr_reader :page_number, :page_size, :sort, :collapse_uuids, :use_exact_count
 
-  def initialize(logger:, type_definition:, filter:, page:, sort:, highlight:, collapse_uuids:, search_configuration:)
+  def initialize(logger:, type_definition:, filter:, page:, sort:, count:, highlight:, collapse_uuids:, search_configuration:)
     @logger = logger
     @type_def = type_definition
     @filter = filter
     @page_number = page && page["number"] ? page["number"].to_i : 0
     @page_size = page && page["size"] ? page["size"].to_i : 10
     @sort = sort
+    @use_exact_count = count == "exact"
     @highlight = highlight
     @collapse_uuids = true? collapse_uuids
     @configuration = search_configuration
@@ -86,7 +87,7 @@ class ElasticQueryBuilder
   end
 
   def build_pagination
-    @es_query["track_total_hits"] = true if @configuration[:use_exact_counts]
+    @es_query["track_total_hits"] = true if @use_exact_count
     @es_query["from"] = @page_number * @page_size
     @es_query["size"] = @page_size
     self

--- a/lib/mu_search/config_parser.rb
+++ b/lib/mu_search/config_parser.rb
@@ -14,6 +14,7 @@ module MuSearch
         common_terms_cutoff_frequency: 0.001,
         attachment_path_base: "/data",
         eager_indexing_groups: [],
+        use_exact_counts: false,
         update_wait_interval_minutes: 1,
         number_of_threads: 1,
         enable_raw_dsl_endpoint: false
@@ -30,6 +31,7 @@ module MuSearch
         { name: "persist_indexes", parser: :parse_boolean },
         { name: "enable_raw_dsl_endpoint", parser: :parse_boolean },
         { name: "automatic_index_updates", parser: :parse_boolean },
+        { name: "use_exact_counts", parser: :parse_boolean },
         { name: "attachments_path_base", parser: :parse_string },
         { name: "common_terms_cutoff_frequency", parser: :parse_float },
         { name: "update_wait_interval_minutes", parser: :parse_integer },

--- a/lib/mu_search/config_parser.rb
+++ b/lib/mu_search/config_parser.rb
@@ -14,7 +14,6 @@ module MuSearch
         common_terms_cutoff_frequency: 0.001,
         attachment_path_base: "/data",
         eager_indexing_groups: [],
-        use_exact_counts: false,
         update_wait_interval_minutes: 1,
         number_of_threads: 1,
         enable_raw_dsl_endpoint: false
@@ -31,7 +30,6 @@ module MuSearch
         { name: "persist_indexes", parser: :parse_boolean },
         { name: "enable_raw_dsl_endpoint", parser: :parse_boolean },
         { name: "automatic_index_updates", parser: :parse_boolean },
-        { name: "use_exact_counts", parser: :parse_boolean },
         { name: "attachments_path_base", parser: :parse_string },
         { name: "common_terms_cutoff_frequency", parser: :parse_float },
         { name: "update_wait_interval_minutes", parser: :parse_integer },

--- a/web.rb
+++ b/web.rb
@@ -179,8 +179,7 @@ get "/:path/search" do |path|
     indexes = index_manager.fetch_indexes(type_def["type"], allowed_groups)
 
     search_configuration = {
-      common_terms_cutoff_frequency: settings.common_terms_cutoff_frequency,
-      use_exact_counts: settings.use_exact_counts,
+      common_terms_cutoff_frequency: settings.common_terms_cutoff_frequency
     }
     query_builder = ElasticQueryBuilder.new(
       logger: SinatraTemplate::Utils.log,
@@ -188,6 +187,7 @@ get "/:path/search" do |path|
       filter: params["filter"],
       page: params["page"],
       sort: params["sort"],
+      count: params["count"],
       highlight: params["highlight"],
       collapse_uuids: params["collapse_uuids"],
       search_configuration: search_configuration)
@@ -209,7 +209,7 @@ get "/:path/search" do |path|
       count =
         if query_builder.collapse_uuids
           search_results.dig("aggregations", "type_count", "value")
-        elsif settings.use_exact_counts
+        elsif query_builder.use_exact_count
           search_results.dig("hits", "total", "value")
         else
           count_query = query_builder.build_count_query


### PR DESCRIPTION
~If the flag is enabled, `track_total_hits` is set to `true` in the search request body. This ensures an exact result count is returned by ES. Enabling it comes at the cost of some performance, but on the other hand it saves an additional count query to ES.~

Add support for a query param `count` on the search endpoint. If set to `exact` it ensures an exact result count is returned by ES. Enabling it comes at the cost of some performance, but on the other hand it saves an additional count query to ES.

More info on the `track_total_hits` option can be found in the [ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-type).