### PR TITLE
arm64 builds

### DIFF
--- a/.woodpecker/.dry-run.yml
+++ b/.woodpecker/.dry-run.yml
@@ -2,7 +2,7 @@ pipeline:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       dry-run: true
     secrets: [docker_username, docker_password]

--- a/.woodpecker/.dry-run.yml
+++ b/.woodpecker/.dry-run.yml
@@ -1,5 +1,5 @@
 pipeline:
-  build-and-push:
+  dry-run:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       platforms: linux/amd64, linux/arm64

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -8,7 +8,7 @@ pipeline:
   build-and-push-latest:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]

--- a/.woodpecker/.pr.yml
+++ b/.woodpecker/.pr.yml
@@ -8,7 +8,7 @@ pipeline:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      platforms: linux/amd64
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,11 @@
 pipeline:
-  release:
-    image: plugins/docker
+  build-and-push-release:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
+      platforms: linux/amd64, linux/arm64
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
 when:
   event: tag
   tag: v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-jruby-template:3.0.0
+FROM semtech/mu-jruby-template:3.1.0
 
 LABEL maintainer="redpencil <info@redpencil.io>"
 # 200MB


### PR DESCRIPTION
Adds arm64 builds of mu-search. This slow down the build quite a bit, but at 4:30 minutes it's still acceptable.
Should make it a bit faster for mac users and resolve the issue with a bug in Rosetta that causes amd64 java to crash on older mac os versions.