### PR TITLE
Add support to filter by uuid and URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- feature: add support to filter by id and URI using filter flags :id: and :uri:
+
 ## v0.10.0-beta.3
 - change: Use 1 construct query instead of 1 query per property to fetch properties for a document
 

--- a/README.md
+++ b/README.md
@@ -839,6 +839,12 @@ To search for `document`s on multiple fields, combined with 'OR':
 GET /documents/search?filter[name,description]=fish
 ```
 
+To search for `document`s by their URI:
+
+```
+GET /documents/search?filter[:uri:]=http://data.semte.ch/documents/c020b82b-61f6-4264-93c5-aba0d09812d3
+```
+
 ##### Searching in a file property
 To search for a field indexing a file, a specific property of the resulting attachment object must be specified as filter key using the `.`-notation.
 
@@ -858,6 +864,10 @@ GET /documents/search?filter[:term:tag]=fish
 ```
 
 The following sections list the flags that are currently implemented:
+
+###### Identifier queries
+- `:id:` Filter documents by their uuid. Multiple values should be comma-seperated, such as `filter[:id:]=c9e0fe90-3785-4221-9c4b-bda70bd8d83b,e8cbc03a-97e0-4b97-931b-97caa720db14`
+- `:uri:` Filter documents by their URI. Multiple values should be comma-seperated.
 
 ###### Term-level queries
 - `:term:` : [Term query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html)

--- a/framework/elastic_query_builder.rb
+++ b/framework/elastic_query_builder.rb
@@ -150,6 +150,11 @@ class ElasticQueryBuilder
   # - filter_key: key of the filter param (e.g. :fuzzy:title,description)
   # - value: value of the filter param
   def construct_es_query_term(filter_key, value)
+    # Preprocess syntactic sugar
+    filter_key = ":terms:uuid" if filter_key == ":id:"
+    filter_key = ":terms:_id" if filter_key == ":uri:"
+
+    # Parse filter key
     flag, fields = split_filter filter_key
 
     case flag


### PR DESCRIPTION
Filter syntax is in line with mu-cl-resources:
- `filter[:id:]` to search by uuid
- `filter[:uri:]` to search by URI

Both filters support multiple values.