### PR TITLE
Allow wait interval less than a minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Features**
 - Add query param to get exact count in search results
 - Add filter flags :id: and :uri: to filter by id and URI
+- Support wait interval less than 1 min in update handler
 
 ## v0.10.0-beta.3
 - change: Use 1 construct query instead of 1 query per property to fetch properties for a document

--- a/lib/mu_search/config_parser.rb
+++ b/lib/mu_search/config_parser.rb
@@ -32,7 +32,7 @@ module MuSearch
         { name: "automatic_index_updates", parser: :parse_boolean },
         { name: "attachments_path_base", parser: :parse_string },
         { name: "common_terms_cutoff_frequency", parser: :parse_float },
-        { name: "update_wait_interval_minutes", parser: :parse_integer },
+        { name: "update_wait_interval_minutes", parser: :parse_float },
         { name: "number_of_threads", parser: :parse_integer }
       ].each do |setting|
         name = setting[:name]


### PR DESCRIPTION
By parsing update_wait_interval_minutes as float instead of integer the user is able to specify a wait interval less than a minute.