### PR TITLE
Group updates sent to Elasticsearch per delta message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add filter flags :id: and :uri: to filter by id and URI
 - Support wait interval less than 1 min in update handler
 
+**Changes**
+- Determine documents to be updated in Elasticsearch per delta message instead of per triple
+
 ## v0.10.0-beta.3
 - change: Use 1 construct query instead of 1 query per property to fetch properties for a document
 

--- a/lib/mu_search/delta_handler.rb
+++ b/lib/mu_search/delta_handler.rb
@@ -80,9 +80,7 @@ module MuSearch
       @logger.debug("DELTA") { "Handling delta: #{triples.inspect}" }
       search_configs = Set.new
       triples.each do |triple|
-        triples.each do |triple|
-          search_configs += applicable_index_configurations_for_triple(triple)
-        end
+        search_configs += applicable_index_configurations_for_triple(triple)
         type_names = search_configs.map(&:name)
         @logger.debug("DELTA") { "Delta affects #{type_names.length} search indexes: #{type_names.join(', ')}" }
       end

--- a/lib/mu_search/delta_handler.rb
+++ b/lib/mu_search/delta_handler.rb
@@ -43,7 +43,7 @@ module MuSearch
               handle_queue_entry(triples, resource_configs)
             end
           rescue StandardError => e
-            #@logger.error("DELTA") { "Failed processing delta #{delta.pretty_inspect}" }
+            @logger.error("DELTA") { "Failed processing delta #{delta.pretty_inspect}" }
             @logger.error("DELTA") { e.full_message }
           end
           sleep 0.05

--- a/lib/mu_search/index_definition.rb
+++ b/lib/mu_search/index_definition.rb
@@ -143,6 +143,8 @@ module MuSearch
     def full_property_paths_for(property)
       if matches_property?(property)
         @property_path_cache[property] + @property_path_cache["^#{property}"]
+      else
+        []
       end
     end
 


### PR DESCRIPTION
Determines affected indexes and documents to update in Elasticsearch per delta message instead of per triple. 

Reduces the amount of document updates sent to Elasticsearch for delta messages with overlapping subjects. For sure when used in combination with the delta bundling released in delta-notifier v0.3.0.