### PR TITLE
support large yaml files

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -34,6 +34,7 @@ WEBrick::HTTPRequest.const_set("MAX_URI_LENGTH", max_uri_length)
 max_header_length = ENV["MAX_REQUEST_HEADER_LENGTH"].to_i > 0 ? ENV["MAX_REQUEST_HEADER_LENGTH"].to_i : 1024000
 Mu::log.info("SETUP") { "Set WEBrick MAX_HEADER_LENGTH to #{max_header_length}" }
 WEBrick::HTTPRequest.const_set("MAX_HEADER_LENGTH", max_header_length)
+Psych::Parser.code_point_limit= 20_000_000
 
 Mu::log.formatter = proc do |severity, datetime, progname, msg|
   "#{severity} [\##{$$}] #{progname} -- #{msg}\n"


### PR DESCRIPTION
fixes #92. This bug was introduced in beta.5 as snakeyaml was upgraded in jruby to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes). This release introduced a safe file size limit of 3MB. We currently overwrite this default and set up a default of 20MB, which we may want to make configurable later on.