### PR TITLE
make the max yaml size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ This section gives an overview of all options that are configurable via environm
 - **MAX_REQUEST_HEADER_LENGTH** : maximum length of the headers of an incoming request. Defaults to 1024000.
 - **MAXIMUM_FILE_SIZE** : maximum size in bytes of files to extract and index content from. Defaults to 209715200.
 - **ELASTIC_READ_TIMEOUT** : timeout in seconds of requests to Elasticsearch. Defaults to 180.
+- **MAX_YAML_SIZE**: Set the code point limit for the psych yaml parser (in bytes), affects the maximum queue size that can be stored (and read). defaults to 20_000_000 bytes.
 
 ## Discussions
 ### Why a custom Elasticsearch docker image?

--- a/web.rb
+++ b/web.rb
@@ -34,7 +34,8 @@ WEBrick::HTTPRequest.const_set("MAX_URI_LENGTH", max_uri_length)
 max_header_length = ENV["MAX_REQUEST_HEADER_LENGTH"].to_i > 0 ? ENV["MAX_REQUEST_HEADER_LENGTH"].to_i : 1024000
 Mu::log.info("SETUP") { "Set WEBrick MAX_HEADER_LENGTH to #{max_header_length}" }
 WEBrick::HTTPRequest.const_set("MAX_HEADER_LENGTH", max_header_length)
-Psych::Parser.code_point_limit= 20_000_000
+max_yaml_size = ENV["MAX_YAML_SIZE"].to_i > 0 ? ENV["MAX_YAML_SIZE"].to_i : 20_000_000
+Psych::Parser.code_point_limit= max_yaml_size
 
 Mu::log.formatter = proc do |severity, datetime, progname, msg|
   "#{severity} [\##{$$}] #{progname} -- #{msg}\n"


### PR DESCRIPTION
in some cases the queue might get larger than our default 20MB. Allow users to override the max yaml size where desirable